### PR TITLE
Updated aurelia-config to version 0.2.0-0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "dist": "dist/amd"
     },
     "dependencies": {
-      "aurelia-config": "^0.1.1",
+      "aurelia-config": "^0.2.0-0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-validation": "^1.0.0"
     },
@@ -49,13 +49,13 @@
     },
     "jspmPackage": true,
     "peerDependencies": {
-      "aurelia-config": "^0.1.1",
+      "aurelia-config": "^0.2.0-0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-validation": "^1.0.0"
     }
   },
   "dependencies": {
-    "aurelia-config": "^0.1.1",
+    "aurelia-config": "^0.2.0-0",
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-validation": "^1.0.0"
   },


### PR DESCRIPTION
There is an issue using aurelia-form-validation package with webpack. This has to do with an older version of aurelia-config being bundled with it. By updating aurelia-config in the package.json to version 0.2.0-0 and creating a new npm package will fix the issue.